### PR TITLE
add support section to jobseeker nav bar

### DIFF
--- a/arena-ui/src/components/Employer/EmployerNav.jsx
+++ b/arena-ui/src/components/Employer/EmployerNav.jsx
@@ -117,7 +117,7 @@ const HelpDropDownContent = styled.div`
   background-color: #f1f1f1;
   width: 80%;
   padding: 0.5rem 1rem;
-  box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+  box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.1);
   z-index: 1;
 `
 const DropDownLink = styled.a`
@@ -126,7 +126,7 @@ const DropDownLink = styled.a`
 
   color: #4a90e2;
   font-weight: 600;
-  font-size: 0.875em;
+  font-size: 0.870em;
   text-decoration: none;
   transition: color 0.2s;
 `
@@ -183,7 +183,6 @@ function EmployerNav() {
 
       </Nav>
       <BottomSection>
-<<<<<<< HEAD
         <HelpDropDown>
           <NavButton onClick={handleHelpDropDown}>
             <ButtonText>Need Help?</ButtonText>
@@ -196,13 +195,11 @@ function EmployerNav() {
             </HelpDropDownContent>
           )}
         </HelpDropDown>
-=======
-      <NavButton onClick={handleQR}>
-      <IconWrapper><QrCodeIcon size={20} /></IconWrapper>
 
-        <ButtonText>QR Code</ButtonText>
-      </NavButton>
->>>>>>> 29216eb69107149b049e1e8d8d171afb64be9eb8
+        <NavButton onClick={handleQR}>
+      <IconWrapper><QrCodeIcon  size={20} /></IconWrapper>
+        <ButtonText> QR Code</ButtonText>
+        </NavButton>
         <NavButton href="/employer-account">
           <IconWrapper><Settings size={20} /></IconWrapper>
           <ButtonText>Account</ButtonText>
@@ -212,13 +209,7 @@ function EmployerNav() {
           <ButtonText>Logout</ButtonText>
         </LogoutButton>
 
-<<<<<<< HEAD
-      <NavButton onClick={handleQR}>
-        <ButtonText>Get QR Code</ButtonText>
-      </NavButton>
-=======
-
->>>>>>> 29216eb69107149b049e1e8d8d171afb64be9eb8
+    
         {isQRPopupOpen && (
           <PopupOverlay>
             <PopupContent>

--- a/arena-ui/src/components/JobSeeker/JobSeekerDash.jsx
+++ b/arena-ui/src/components/JobSeeker/JobSeekerDash.jsx
@@ -125,6 +125,7 @@ const Card = styled.div`
   background-color: #ffffff;
   border-radius: 0.5rem;
   box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+  padding: 1.5rem;
 `;
 
 const CardHeader = styled.div`

--- a/arena-ui/src/components/JobSeeker/JobSeekerNav.jsx
+++ b/arena-ui/src/components/JobSeeker/JobSeekerNav.jsx
@@ -41,6 +41,7 @@ const NavButton = styled.a`
 
   &:hover {
     background-color: #e5e7eb;
+    cursor: pointer;
   }
 `;
 
@@ -104,14 +105,47 @@ const CloseQRNavSection = styled.div`
   flex-direction: row-reverse;
   padding-top: 0.5rem;
 
+`
+const HelpDropDown = styled.div`
+  position: relative;
+`
+const HelpDropDownContent = styled.div`
+  position: absolute;
+  background-color: #f1f1f1;
+  width: 80%;
+  padding: 0.5rem 1rem;
+  box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.1);
+  z-index: 1;
+`
+const DropDownLink = styled.a`
+  padding: 10px 0px;
+  display: block;
+
+  color: #4a90e2;
+  font-weight: 600;
+  font-size: 0.870em;
+  text-decoration: none;
+  transition: color 0.2s;
+`
+const LinkText = styled.span`
+  &:hover {
+    color: #63b3ed;
+    text-decoration: underline; /* Underline only applies to the text */
+  }
 `;
 
 function JobSeekerNav(){
   const [isQRPopupOpen, setIsQRPopupOpen] = useState(false);
+  const [isHelpDropDownOpen, setIsHelpDropDownOpen] = useState(false);
 
   const handleQR = () => {
     setIsQRPopupOpen(prev => !prev);
   };
+
+  const handleHelpDropDown = () => {
+    setIsHelpDropDownOpen(prev => !prev);
+  };
+
   return (
     <NavContainer>
       <LogoContainer>
@@ -145,6 +179,17 @@ function JobSeekerNav(){
 
       </Nav>
       <BottomSection>
+      <HelpDropDown>
+          <NavButton onClick={handleHelpDropDown}>
+            <ButtonText>Need Help?</ButtonText>
+          </NavButton>
+          {isHelpDropDownOpen && (
+            <HelpDropDownContent>
+              <DropDownLink href="">📘 <LinkText>Help & quick start guide</LinkText></DropDownLink>
+              <DropDownLink href="mailto:support@arenatalent.com"><LinkText>Email us</LinkText></DropDownLink>
+            </HelpDropDownContent>
+          )}
+        </HelpDropDown>
       <NavButton onClick={handleQR}>
       <IconWrapper><QrCodeIcon  size={20} /></IconWrapper>
         <ButtonText> QR Code</ButtonText>


### PR DESCRIPTION

Resolves # 17

## Description


On bottom section of the Jobseeker Nav Bar, create a new button that generates a dropdown menu of help features. Hyperlinks go to help guide (link not added yet), and support email.

Also added the QR code icon to employer nav, padding to Jobseeker Card components to fix styling on the "Complete your profile" and "Get noticed" sections, and added background hover on nav buttons in Jobseeker to match styling of Employer Nav. 


## Motivation and Context

Allows for Employers to gain access to help/ support materials seamlessly.

Other updates create cohesion in styling between Jobseeker and Employer side.

## How Can This Be Tested

Tested locally.

## Screenshots:
<img width="1436" alt="image" src="https://github.com/user-attachments/assets/9a33c495-e7c9-43c4-9984-09233c5f1067">
<img width="272" alt="image" src="https://github.com/user-attachments/assets/be0333c7-4d4e-4088-8937-df24f399f2c8"> 
<img width="238" alt="image" src="https://github.com/user-attachments/assets/31c2c544-ef18-4544-ae65-f1534d3c7e69">




## Checklist:


- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have tested my branch
